### PR TITLE
Add a maintask to move podcast images urls to podcast extras attribute

### DIFF
--- a/app/tasks/maintenance/move_image_urls_task.rb
+++ b/app/tasks/maintenance/move_image_urls_task.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Maintenance
+  class MoveImageUrlsTask < MaintenanceTasks::Task
+    def collection
+      Podcast.all
+    end
+
+    def process(podcast)
+      if podcast.extras["image_urls"].nil?
+        images = []
+
+        podcast.image_urls.each do |image|
+          images << {url: image.url, height: image.height, width: image.width}
+        end
+
+        podcast.extras = {image_urls: images}
+        podcast.save!
+      end
+    end
+  end
+end

--- a/app/tasks/maintenance/move_image_urls_task.rb
+++ b/app/tasks/maintenance/move_image_urls_task.rb
@@ -7,16 +7,16 @@ module Maintenance
     end
 
     def process(podcast)
-      if podcast.extras["image_urls"].nil?
-        images = []
+      return if podcast.extras["image_urls"].present?
 
-        podcast.image_urls.each do |image|
-          images << {url: image.url, height: image.height, width: image.width}
-        end
+      images = []
 
-        podcast.extras = {image_urls: images}
-        podcast.save!
+      podcast.image_urls.each do |image|
+        images << {url: image.url, height: image.height, width: image.width}
       end
+
+      podcast.extras = {image_urls: images}
+      podcast.save!
     end
   end
 end

--- a/spec/factories/podcasts.rb
+++ b/spec/factories/podcasts.rb
@@ -4,5 +4,9 @@ FactoryBot.define do
     description { Faker::Lorem.paragraph }
     language { Faker::Address.country_code }
     publisher { Faker::Name.first_name_neutral }
+
+    trait :with_extras do
+      extras { {image_urls: [{url: Faker::LoremFlickr.image}, {url: Faker::LoremFlickr.image}, {url: Faker::LoremFlickr.image}]} }
+    end
   end
 end

--- a/spec/tasks/maintenance/move_image_urls_task_spec.rb
+++ b/spec/tasks/maintenance/move_image_urls_task_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Maintenance
+  RSpec.describe MoveImageUrlsTask do
+    it "move imagas urls to a podcast extra field" do
+      podcast = FactoryBot.create(:podcast)
+      image_url = FactoryBot.create_list(:image_url, 3, podcast: podcast)
+
+      Maintenance::MoveImageUrlsTask.process(podcast)
+
+      expect(podcast.extras).not_to be_empty
+      expect(podcast.extras["image_urls"].count).to eq(3)
+      expect(podcast.extras["image_urls"].first["url"]).to eq(image_url.first.url)
+    end
+  end
+end

--- a/spec/tasks/maintenance/move_image_urls_task_spec.rb
+++ b/spec/tasks/maintenance/move_image_urls_task_spec.rb
@@ -4,8 +4,9 @@ require "rails_helper"
 
 module Maintenance
   RSpec.describe MoveImageUrlsTask do
-    it "move imagas urls to a podcast extra field" do
+    it "move images urls to a podcast extra field" do
       podcast = FactoryBot.create(:podcast)
+
       image_url = FactoryBot.create_list(:image_url, 3, podcast: podcast)
 
       Maintenance::MoveImageUrlsTask.process(podcast)
@@ -13,6 +14,14 @@ module Maintenance
       expect(podcast.extras).not_to be_empty
       expect(podcast.extras["image_urls"].count).to eq(3)
       expect(podcast.extras["image_urls"].first["url"]).to eq(image_url.first.url)
+    end
+
+    it "shouldn't move images urls to a podcast extra field if the podcast has already" do
+      podcast = FactoryBot.create(:podcast, :with_extras)
+
+      Maintenance::MoveImageUrlsTask.process(podcast)
+
+      expect(podcast.extras["image_urls"]).to eq(podcast.extras["image_urls"])
     end
   end
 end


### PR DESCRIPTION
Here we created a new attributes on podcast modal. https://github.com/enderahmetyurt/podiscover/pull/147

Now we're migrating all ImageUrl data to related podcast extras field.

This maintaintask will be run after this PR is merged.