### PR TITLE
Fetch last image instead first

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -101,7 +101,7 @@ class User < ApplicationRecord
   def self.image(auth)
     return nil if auth.info.images.empty?
 
-    profile_image_url = auth.info.images.first.url
+    profile_image_url = auth.info.images.last.url
 
     begin
       URI.parse(profile_image_url).open


### PR DESCRIPTION
Spotify added bigger image as last element of user images JSON attribute.

Users need to login again to fix their images.